### PR TITLE
Emerge fail fix

### DIFF
--- a/dev-libs/libblocksruntime/libblocksruntime-0.4.1.ebuild
+++ b/dev-libs/libblocksruntime/libblocksruntime-0.4.1.ebuild
@@ -19,19 +19,19 @@ DEPEND="sys-devel/clang"
 RDEPEND="${DEPEND}"
 
 src_configure() {
-        export CC=clang
-        export CXX=clang++
+    export CC=clang
+    export CXX=clang++
 
-       	append-flags -fblocks
+    append-flags -fblocks
 
-       	local mycmakeargs="-DDISPATCH_INCLUDE_DIR=include"
-        cmake-multilib_src_configure
+    local mycmakeargs="-DDISPATCH_INCLUDE_DIR=include"
+    cmake-multilib_src_configure
 }
 
 src_install() {
-        cmake-multilib_src_install
+    cmake-multilib_src_install
 
-        #insinto /usr/include/dispatch
-        #doins "${FILESDIR}/dispatch.h"
-        #dosym dispatch/dispatch.h /usr/include/dispatch/dispatch.h
+    #insinto /usr/include/dispatch
+    #doins "${FILESDIR}/dispatch.h"
+    #dosym dispatch/dispatch.h /usr/include/dispatch/dispatch.h
 }

--- a/dev-libs/libblocksruntime/libblocksruntime-0.4.1.ebuild
+++ b/dev-libs/libblocksruntime/libblocksruntime-0.4.1.ebuild
@@ -17,3 +17,21 @@ IUSE=""
 
 DEPEND="sys-devel/clang"
 RDEPEND="${DEPEND}"
+
+src_configure() {
+        export CC=clang
+        export CXX=clang++
+
+       	append-flags -fblocks
+
+       	local mycmakeargs="-DDISPATCH_INCLUDE_DIR=include"
+        cmake-multilib_src_configure
+}
+
+src_install() {
+        cmake-multilib_src_install
+
+        #insinto /usr/include/dispatch
+        #doins "${FILESDIR}/dispatch.h"
+        #dosym dispatch/dispatch.h /usr/include/dispatch/dispatch.h
+}


### PR DESCRIPTION
Adding src_configure() and src_install() prevents a failing build process that reports the compiler is unable to build executables.